### PR TITLE
Revert "FHIR objectmapper upadation in generate ABHA "

### DIFF
--- a/src/main/java/com/wipro/fhir/service/ndhm/GenerateHealthID_CardServiceImpl.java
+++ b/src/main/java/com/wipro/fhir/service/ndhm/GenerateHealthID_CardServiceImpl.java
@@ -34,7 +34,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -79,8 +78,7 @@ public class GenerateHealthID_CardServiceImpl implements GenerateHealthID_CardSe
 
 			String ndhmAuthToken = generateSession_NDHM.getNDHMAuthToken();
 			Map<String, String> responseMap = new HashMap<String, String>();
-			ObjectMapper objectMapper = new ObjectMapper();
-			SendOTPForCard obj = objectMapper.convertValue(request, SendOTPForCard.class);
+			SendOTPForCard obj = InputMapper.gson().fromJson(request, SendOTPForCard.class);
 
 			Map<String, Object> requestMap = null;
 			requestMap = new HashMap<String, Object>();


### PR DESCRIPTION
Reverts PSMRI/FHIR-API#81

reverting this commit as this change is no longer required... will work without it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the method for processing OTP requests by switching JSON deserialization from Jackson to Gson. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->